### PR TITLE
feat(auth): Add password strength indicator to registration

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -252,6 +252,24 @@ export function AuthForm({ mode }: AuthFormProps) {
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
               </div>
+
+              {/* Password Strength Indicator */}
+              {registerForm.watch('password') && (
+                <div className="space-y-1">
+                  <div className="flex gap-1">
+                    <div className={`h-1 flex-1 rounded ${registerForm.watch('password').length >= 8 ? 'bg-green-500' : 'bg-gray-200'}`}></div>
+                    <div className={`h-1 flex-1 rounded ${registerForm.watch('password').length >= 10 && /[A-Z]/.test(registerForm.watch('password')) ? 'bg-green-500' : 'bg-gray-200'}`}></div>
+                    <div className={`h-1 flex-1 rounded ${registerForm.watch('password').length >= 12 && /[A-Z]/.test(registerForm.watch('password')) && /[0-9]/.test(registerForm.watch('password')) ? 'bg-green-500' : 'bg-gray-200'}`}></div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {registerForm.watch('password').length < 8 && 'Mật khẩu yếu'}
+                    {registerForm.watch('password').length >= 8 && registerForm.watch('password').length < 10 && 'Mật khẩu trung bình'}
+                    {registerForm.watch('password').length >= 10 && /[A-Z]/.test(registerForm.watch('password')) && 'Mật khẩu mạnh'}
+                    {registerForm.watch('password').length >= 12 && /[A-Z]/.test(registerForm.watch('password')) && /[0-9]/.test(registerForm.watch('password')) && 'Mật khẩu rất mạnh'}
+                  </p>
+                </div>
+              )}
+
               {registerForm.formState.errors.password && (
                 <p className="text-sm text-destructive">{registerForm.formState.errors.password.message}</p>
               )}


### PR DESCRIPTION
- Add visual strength meter with 3 levels
- Show strength text (weak/medium/strong/very strong)
- Check for length, uppercase, and numbers
- Real-time feedback as user types

## Description
<!-- Describe your changes in detail -->

## Type of change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested locally
- [ ] Build passes
- [ ] Tested on mobile
- [ ] Tested authentication flows

## Checklist:
<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
<!-- Add screenshots to help explain your changes -->

## Additional Notes:
<!-- Add any additional notes or context -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a password strength indicator to the registration form to guide users with clear, real-time feedback. Improves sign-up UX and encourages stronger passwords.

- **New Features**
  - 3-segment strength bar that fills as criteria are met.
  - Strength labels: weak, medium, strong, very strong.
  - Criteria: length ≥ 8; length ≥ 10 + uppercase; length ≥ 12 + uppercase + number.
  - Updates live as the user types.

<sup>Written for commit f77c3d3c706690b0f64ada2233140638d4d99ded. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

