### PR TITLE
feat(auth): Add Remember Me checkbox to login form

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -184,7 +184,17 @@ export function AuthForm({ mode }: AuthFormProps) {
               )}
             </div>
 
-            <div className="flex justify-end">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  id="remember"
+                  className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                />
+                <label htmlFor="remember" className="text-sm text-gray-700 cursor-pointer">
+                  Ghi nhớ đăng nhập
+                </label>
+              </div>
               <Link to="/forgot-password" className="text-sm text-primary hover:text-primary/80 hover:underline transition-colors font-medium">
                 Quên mật khẩu?
               </Link>


### PR DESCRIPTION
- Add checkbox with proper styling
- Position between password and forgot password link
- Improve user experience for returning users
- Prepare for persistent login implementation

## Description
<!-- Describe your changes in detail -->

## Type of change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested locally
- [ ] Build passes
- [ ] Tested on mobile
- [ ] Tested authentication flows

## Checklist:
<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
<!-- Add screenshots to help explain your changes -->

## Additional Notes:
<!-- Add any additional notes or context -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a "Remember me" checkbox to the login form to improve returning user experience and prepare for persistent sessions. It’s styled and placed on the left of the action row, opposite the "Forgot password?" link.

<sup>Written for commit b17f76671718598aba472c156a71f6bbe019f690. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Remember me" checkbox to the login form, positioned alongside the forgot-password link for enhanced user convenience during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->