### PR TITLE
feat: Add Error Boundary component

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+    children: ReactNode;
+    fallback?: ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+    error?: Error;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+    public state: State = {
+        hasError: false,
+    };
+
+    public static getDerivedStateFromError(error: Error): State {
+        return { hasError: true, error };
+    }
+
+    public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        console.error('Uncaught error:', error, errorInfo);
+    }
+
+    private handleReset = () => {
+        this.setState({ hasError: false, error: undefined });
+        window.location.href = '/';
+    };
+
+    public render() {
+        if (this.state.hasError) {
+            if (this.props.fallback) {
+                return this.props.fallback;
+            }
+
+            return (
+                <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-red-50 to-orange-50">
+                    <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center">
+                        <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
+                            <AlertTriangle className="w-8 h-8 text-red-600" />
+                        </div>
+                        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+                            Oops! Có lỗi xảy ra
+                        </h1>
+                        <p className="text-gray-600 mb-6">
+                            Đã có lỗi không mong muốn xảy ra. Vui lòng thử lại hoặc quay về trang chủ.
+                        </p>
+                        {this.state.error && (
+                            <details className="mb-6 text-left">
+                                <summary className="cursor-pointer text-sm text-gray-500 hover:text-gray-700">
+                                    Chi tiết lỗi
+                                </summary>
+                                <pre className="mt-2 p-3 bg-gray-100 rounded text-xs overflow-auto">
+                                    {this.state.error.message}
+                                </pre>
+                            </details>
+                        )}
+                        <Button onClick={this.handleReset} className="w-full">
+                            Quay về trang chủ
+                        </Button>
+                    </div>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}


### PR DESCRIPTION
- Create reusable error boundary for error handling
- Add user-friendly error UI with Vietnamese text
- Include error details in collapsible section
- Add reset button to return to homepage

## Description
<!-- Describe your changes in detail -->

## Type of change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested locally
- [ ] Build passes
- [ ] Tested on mobile
- [ ] Tested authentication flows

## Checklist:
<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
<!-- Add screenshots to help explain your changes -->

## Additional Notes:
<!-- Add any additional notes or context -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable ErrorBoundary component that catches runtime errors and shows a friendly Vietnamese error screen. Includes an optional fallback and a reset button that returns users to the homepage.

- **New Features**
  - Reusable ErrorBoundary with optional fallback prop.
  - Default UI: alert icon, concise Vietnamese copy, collapsible error details.
  - Reset action clears error state and navigates to '/'.

<sup>Written for commit d25c1b0b6cf61bf2199db5c6fab8e3c74d67bc70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

