### PR TITLE
fix: normalize Vietnamese diacritics in search

### DIFF
--- a/src/lib/search-utils.ts
+++ b/src/lib/search-utils.ts
@@ -17,3 +17,8 @@ export function highlightMatch(text: string, query: string): string {
   const regex = new RegExp("(" + escaped + ")", "gi");
   return text.replace(regex, "<mark>$1</mark>");
 }
+
+
+export function normalizeVietnamese(str: string): string {
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}


### PR DESCRIPTION
Fix search khong tim duoc tinh thanh co dau.
Closes #19

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Vietnamese text in search so queries match regardless of accents, fixing failures to find names with diacritics. Closes #19.

<sup>Written for commit f378d64285dd0ca9460cb4f99d0f055e8f97bb14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

