### PR TITLE
feat: QR code sharing for trip itineraries

### DIFF
--- a/src/components/QRShareCard.tsx
+++ b/src/components/QRShareCard.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { QrCode, Copy, Check } from 'lucide-react';
+import { useClipboard } from '@/hooks/useClipboard';
+import { generateShareUrl } from '@/lib/share-utils';
+
+interface QRShareCardProps { slug: string; title: string; }
+
+export function QRShareCard({ slug, title }: QRShareCardProps) {
+  const shareUrl = generateShareUrl(slug);
+  const qrUrl = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' + encodeURIComponent(shareUrl);
+  const { copied, copy } = useClipboard();
+  return (
+    <Card className='w-fit'>
+      <CardHeader className='pb-2'>
+        <CardTitle className='text-sm flex items-center gap-2'>
+          <QrCode className='h-4 w-4' /> Chia se lich trinh
+        </CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-3'>
+        <img src={qrUrl} alt={'QR ' + title} className='rounded-lg mx-auto' width={200} height={200} />
+        <Button variant='outline' size='sm' className='w-full' onClick={() => copy(shareUrl)}>
+          {copied ? <Check className='h-4 w-4 mr-1' /> : <Copy className='h-4 w-4 mr-1' />}
+          {copied ? 'Da copy!' : 'Copy link'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Add QR code for sharing.
Closes #14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds QR code sharing for trip itineraries via a new QRShareCard component, letting users scan a code or copy the share link. Implements the sharing flow requested in issue #14.

- **New Features**
  - New QRShareCard component (props: slug, title).
  - Builds share URL with generateShareUrl and renders a 200x200 QR via api.qrserver.com.
  - Copy link button using useClipboard with visual feedback (Copy/Check icons).

<sup>Written for commit 491baf1118ae9e4d00c52325733ecaaee95b334b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new share card component that enables users to share content via QR code. The component displays a scannable QR code image and provides a one-click button to copy the share link to their clipboard, with visual feedback confirming successful copy action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->