### PR TITLE
feat: lazy load images with IntersectionObserver

### DIFF
--- a/src/components/LazyImage.tsx
+++ b/src/components/LazyImage.tsx
@@ -1,0 +1,21 @@
+import { useState, useRef, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+interface LazyImageProps { src: string; alt: string; className?: string; }
+export function LazyImage({ src, alt, className }: LazyImageProps) {
+  const [loaded, setLoaded] = useState(false);
+  const [inView, setInView] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) { setInView(true); observer.disconnect(); }
+    }, { rootMargin: '200px' });
+    if (ref.current) observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+  return (
+    <div ref={ref} className={cn('overflow-hidden bg-muted', className)}>
+      {inView && <img src={src} alt={alt} loading='lazy' onLoad={() => setLoaded(true)}
+        className={cn('w-full h-full object-cover transition-opacity duration-500', loaded ? 'opacity-100' : 'opacity-0')} />}
+    </div>
+  );
+}


### PR DESCRIPTION
Performance: lazy load images.
Relates to #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a LazyImage component that uses IntersectionObserver to load images when they’re near the viewport and fade them in. This improves initial load and scroll performance and addresses Linear #20.

<sup>Written for commit eda3c386214f195e5f3d4e61134d2452c3f126a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

