### PR TITLE
feat: virtual scrolling for large trip lists

### DIFF
--- a/src/hooks/useVirtualScroll.ts
+++ b/src/hooks/useVirtualScroll.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect, useRef } from 'react';
+interface UseVirtualScrollOptions { itemCount: number; itemHeight: number; overscan?: number; }
+export function useVirtualScroll({ itemCount, itemHeight, overscan = 5 }: UseVirtualScrollOptions) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+  useEffect(() => {
+    const c = containerRef.current; if (!c) return;
+    setContainerHeight(c.clientHeight);
+    const h = () => setScrollTop(c.scrollTop);
+    c.addEventListener('scroll', h); return () => c.removeEventListener('scroll', h);
+  }, []);
+  const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - overscan);
+  const endIndex = Math.min(itemCount - 1, Math.ceil((scrollTop + containerHeight) / itemHeight) + overscan);
+  return { containerRef, startIndex, endIndex, totalHeight: itemCount * itemHeight, offsetY: startIndex * itemHeight };
+}


### PR DESCRIPTION
Performance: virtual scroll.
Relates to #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable virtual scrolling hook for large trip lists to render only visible items, improving scroll performance and reducing DOM nodes. Addresses #20 by meeting the performance requirement for large lists.

- **New Features**
  - useVirtualScroll returns containerRef, startIndex, endIndex, totalHeight, and offsetY.
  - Computes indices from scrollTop and itemHeight with configurable overscan (default 5).

<sup>Written for commit 7ee6bec597a380a433dcb23a9268a2f0382e45fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

