### PR TITLE
feat: duplicate trip functionality

### DIFF
--- a/src/hooks/useDuplicateTrip.ts
+++ b/src/hooks/useDuplicateTrip.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+export function useDuplicateTrip() {
+  const qc = useQueryClient(); const { toast } = useToast();
+  return useMutation({
+    mutationFn: async (tripId: string) => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error('Not authenticated');
+      const { data: trip } = await supabase.from('trips').select('*').eq('id', tripId).single();
+      if (!trip) throw new Error('Trip not found');
+      const { data, error } = await supabase.from('trips').insert({
+        user_id: user.id, title: trip.title + ' (ban sao)', mode: trip.mode,
+        destination_provinces: trip.destination_provinces, travelers_count: trip.travelers_count,
+        total_budget_vnd: trip.total_budget_vnd, status: 'draft',
+      }).select().single();
+      if (error) throw error; return data;
+    },
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['trips'] }); toast({ title: 'Da tao ban sao!' }); },
+  });
+}


### PR DESCRIPTION
Clone existing trips as draft.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a trip duplication feature so users can clone an existing trip into a new draft. This speeds up trip creation by reusing existing trip details.

- **New Features**
  - Added useDuplicateTrip hook using React Query and Supabase.
  - Requires auth; duplicates an existing trip by ID.
  - Copies title (adds " (ban sao)"), mode, destinations, travelers, budget; sets status to draft.
  - Invalidates the trips list and shows a success toast after creation.

<sup>Written for commit 6f7ccae68c3068515b71c62cfc91e110ec3849ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

