### PR TITLE
fix: mobile responsive improvements

### DIFF
--- a/src/styles/mobile-fixes.css
+++ b/src/styles/mobile-fixes.css
@@ -1,0 +1,7 @@
+@media (max-width: 640px) {
+  .sidebar { width: 100%; position: fixed; z-index: 50; }
+  .dashboard-content { padding: 1rem; }
+  .trip-card-grid { grid-template-columns: 1fr; }
+  .stat-grid { grid-template-columns: repeat(2, 1fr); }
+  .budget-chart { max-width: 100%; overflow-x: auto; }
+}


### PR DESCRIPTION
Fix layout on mobile.
Closes #18

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile layout for screens ≤640px: fixed full-width sidebar, added content padding, single-column trip cards, two-column stats, and horizontally scrollable budget chart (closes #18).

<sup>Written for commit 5b477a0f1f15a473d49c5182ceaace33aef69a60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

